### PR TITLE
Further fix logging of errors in RFS

### DIFF
--- a/RFS/src/main/java/com/rfs/cms/AbstractedHttpClient.java
+++ b/RFS/src/main/java/com/rfs/cms/AbstractedHttpClient.java
@@ -18,13 +18,7 @@ public interface AbstractedHttpClient extends AutoCloseable {
     interface AbstractHttpResponse {
         Stream<Map.Entry<String, String>> getHeaders();
 
-        default byte[] getPayloadBytes() throws IOException {
-            return getPayloadStream().readAllBytes();
-        }
-
-        default InputStream getPayloadStream() throws IOException {
-            return new ByteArrayInputStream(getPayloadBytes());
-        }
+        byte[] getPayloadBytes() throws IOException;
 
         String getStatusText();
 
@@ -63,4 +57,7 @@ public interface AbstractedHttpClient extends AutoCloseable {
         }
         return makeRequest(method, path, combinedHeaders, body);
     }
+
+    @Override
+    default void close() throws Exception {}
 }

--- a/RFS/src/test/java/com/rfs/cms/WorkCoordinatorTest.java
+++ b/RFS/src/test/java/com/rfs/cms/WorkCoordinatorTest.java
@@ -77,7 +77,7 @@ public class WorkCoordinatorTest {
             );
 
         var objectMapper = new ObjectMapper();
-        return objectMapper.readTree(response.getPayloadStream()).path("hits");
+        return objectMapper.readTree(response.getPayloadBytes()).path("hits");
     }
 
     private long getMetricValueOrZero(Collection<MetricData> metrics, String s) {


### PR DESCRIPTION
Adding a new test to affirm the logging of unexpected responses for RFS Work Coordination, I noticed an API bug in the Http Client/Responses.

There was too much wiggle room between the bytes and stream payload accessors.  The logging code assumed that the stream would be recoverable, but as per the existing interface, that wouldn't always be the case (and wasn't in the way that I coded up the first test case that I had tweaked).  Now there's only one API, which requires all payloads to be recoverable indefinitely, mooting the bug. Also, the existing tests were made a big tighter/clearer and a new test was added that goes through the public APIs to make sure that those also log (in case getResult ever gets dropped from their codepaths).

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
